### PR TITLE
Hide private browsing indicator on FF > 132

### DIFF
--- a/src/userChrome/tabmenu.css
+++ b/src/userChrome/tabmenu.css
@@ -8,8 +8,8 @@
      * gives the tab bar a consistent width in both the regular and the private
      * browsing mode, so the increased width hack below looks good in both. */
 
-    hbox.private-browsing-indicator {
-        display: none !important;
+    hbox.private-browsing-indicator-with-label {
+        display: none;
     }
 
     /* Hide firefox-view tab, as none of the options in about:config hides it on FF 123 */


### PR DESCRIPTION
This removes the huge private-browsing indicator. 
As private windows have a different UI color, the large indicator is not necessary.

