### PR TITLE
Esmification: Replace ChromeUtils.import by ChromeUtils.importESModule when available

### DIFF
--- a/src/mobile-config-autoconfig.js
+++ b/src/mobile-config-autoconfig.js
@@ -19,7 +19,15 @@
 
 const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 const Services = globalThis.Services;
-Cu.import("resource://gre/modules/FileUtils.jsm");
+const { AppConstants } = ChromeUtils.importESModule("resource://gre/modules/AppConstants.sys.mjs");
+const IS_ESM_READY = parseInt(AppConstants.MOZ_APP_VERSION, 10) >= 128;
+
+// We need to conditionally load some modules because they haven't been ported
+// the ES module yet. This workaround can be removed when ESR128 will be EOL.
+const { FileUtils } =
+    IS_ESM_READY
+      ? ChromeUtils.importESModule("resource://gre/modules/FileUtils.sys.mjs")
+      : Cu.import("resource://gre/modules/FileUtils.jsm");
 
 var g_ff_version;
 var g_updated = false;


### PR DESCRIPTION
This is an important commit from upstream to make installing/running the config/tweaks with Firefox 136+ possible.

Part-of: https://gitlab.postmarketos.org/postmarketOS/mobile-config-firefox/-/merge_requests/73